### PR TITLE
feat: Add Kafka integration and improve Swagger setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,9 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 SERVICE_VERSION=1.0.0
 
 # Kafka Configuration
-KAFKA_BROKERS=localhost:9092
+KAFKA_BROKER=localhost:9092
 KAFKA_CLIENT_ID=core-pipeline
-KAFKA_GROUP_ID=core-pipeline-group
+KAFKA_CONSUMER_GROUP=core-pipeline-group
 
 # PostgreSQL Configuration
 POSTGRES_HOST=localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,120 @@
+version: '3.8'
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - kafka-network
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9093,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_JMX_PORT: 9101
+      KAFKA_JMX_HOSTNAME: localhost
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    networks:
+      - kafka-network
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      - kafka
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9093
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+    networks:
+      - kafka-network
+
+  app:
+    build: .
+    container_name: core-pipeline
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      KAFKA_BROKER: kafka:9093
+      KAFKA_CLIENT_ID: core-pipeline
+      KAFKA_CONSUMER_GROUP: core-pipeline-group
+      OTEL_SERVICE_NAME: core-pipeline
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
+    depends_on:
+      - kafka
+      - jaeger
+    networks:
+      - kafka-network
+      - monitoring-network
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: jaeger
+    ports:
+      - "16686:16686"
+      - "4318:4318"
+      - "4317:4317"
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    networks:
+      - monitoring-network
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    networks:
+      - monitoring-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+    networks:
+      - monitoring-network
+
+networks:
+  kafka-network:
+    driver: bridge
+  monitoring-network:
+    driver: bridge
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.6",
+        "@nestjs/microservices": "^11.1.6",
         "@nestjs/platform-express": "^11.1.6",
         "@nestjs/swagger": "^11.2.0",
         "@nestjs/terminus": "^11.0.0",
@@ -26,6 +27,9 @@
         "@opentelemetry/sdk-node": "^0.205.0",
         "@opentelemetry/sdk-trace-node": "^2.1.0",
         "@opentelemetry/semantic-conventions": "^1.37.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.2",
+        "kafkajs": "^2.2.4",
         "pino": "^9.12.0",
         "pino-http": "^10.5.0",
         "pino-pretty": "^13.1.1",
@@ -2181,6 +2185,64 @@
         }
       }
     },
+    "node_modules/@nestjs/microservices": {
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.6.tgz",
+      "integrity": "sha512-5ibvCvZ8IBxKhpSkyAC+EBdtm0XVAu3h+GV4PmOi4bXbRvVBT3Kwqq4td2wkWDN3VqteChjQ0aTADv0jizhCrg==",
+      "license": "MIT",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "amqp-connection-manager": "*",
+        "amqplib": "*",
+        "cache-manager": "*",
+        "ioredis": "*",
+        "kafkajs": "*",
+        "mqtt": "*",
+        "nats": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@nestjs/websockets": {
+          "optional": true
+        },
+        "amqp-connection-manager": {
+          "optional": true
+        },
+        "amqplib": {
+          "optional": true
+        },
+        "cache-manager": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "kafkajs": {
+          "optional": true
+        },
+        "mqtt": {
+          "optional": true
+        },
+        "nats": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.6",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.6.tgz",
@@ -4280,6 +4342,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.15.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.3.tgz",
+      "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -5731,6 +5799,23 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.2.tgz",
+      "integrity": "sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
@@ -8783,6 +8868,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/kafkajs": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
+      "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8816,6 +8910,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.23",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.23.tgz",
+      "integrity": "sha512-RN3q3gImZ91BvRDYjWp7ICz3gRn81mW5L4SW+2afzNCC0I/nkXstBgZThQGTE3S/9q5J90FH4dP+TXx8NhdZKg==",
+      "license": "MIT"
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -11695,6 +11795,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
-  "keywords": ["nestjs", "observability", "prometheus", "opentelemetry"],
+  "keywords": [
+    "nestjs",
+    "observability",
+    "prometheus",
+    "opentelemetry"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {
@@ -25,6 +30,7 @@
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.6",
+    "@nestjs/microservices": "^11.1.6",
     "@nestjs/platform-express": "^11.1.6",
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/terminus": "^11.0.0",
@@ -38,6 +44,9 @@
     "@opentelemetry/sdk-node": "^0.205.0",
     "@opentelemetry/sdk-trace-node": "^2.1.0",
     "@opentelemetry/semantic-conventions": "^1.37.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.2",
+    "kafkajs": "^2.2.4",
     "pino": "^9.12.0",
     "pino-http": "^10.5.0",
     "pino-pretty": "^13.1.1",

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'core-pipeline'
+    static_configs:
+      - targets: ['app:3000']
+    metrics_path: '/metrics'
+
+  - job_name: 'kafka'
+    static_configs:
+      - targets: ['kafka:9101']

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { MetricsService } from './services/metrics.service';
 import { TracingMiddleware } from './middleware/tracing.middleware';
 import { LoggingMiddleware } from './middleware/logging.middleware';
 import { MetricsMiddleware } from './middleware/metrics.middleware';
+import { KafkaModule } from './kafka/kafka.module';
 import configuration from './config/configuration';
 
 @Module({
@@ -18,6 +19,7 @@ import configuration from './config/configuration';
       isGlobal: true,
     }),
     TerminusModule,
+    KafkaModule,
   ],
   controllers: [AppController, HealthController, MetricsController],
   providers: [LoggerService, MetricsService],

--- a/src/kafka/controllers/kafka.controller.spec.ts
+++ b/src/kafka/controllers/kafka.controller.spec.ts
@@ -1,0 +1,303 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus } from '@nestjs/common';
+import { KafkaController } from './kafka.controller';
+import { KafkaProducerService } from '../services/kafka-producer.service';
+import { KafkaConsumerService } from '../services/kafka-consumer.service';
+import { EventStorageService } from '../services/event-storage.service';
+import { ProduceMessageDto } from '../dto/produce-message.dto';
+import { KafkaEvent } from '../interfaces/kafka-event.interface';
+
+describe('KafkaController', () => {
+  let controller: KafkaController;
+  let producerService: KafkaProducerService;
+  let consumerService: KafkaConsumerService;
+  let eventStorage: EventStorageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [KafkaController],
+      providers: [
+        {
+          provide: KafkaProducerService,
+          useValue: {
+            produce: jest.fn(),
+            produceMany: jest.fn(),
+          },
+        },
+        {
+          provide: KafkaConsumerService,
+          useValue: {
+            getSubscribedTopics: jest.fn(),
+            subscribeToTopic: jest.fn(),
+          },
+        },
+        {
+          provide: EventStorageService,
+          useValue: {
+            getAllEvents: jest.fn(),
+            getEventsByTopic: jest.fn(),
+            getEvent: jest.fn(),
+            getStats: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<KafkaController>(KafkaController);
+    producerService = module.get<KafkaProducerService>(KafkaProducerService);
+    consumerService = module.get<KafkaConsumerService>(KafkaConsumerService);
+    eventStorage = module.get<EventStorageService>(EventStorageService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('POST /api/kafka/produce', () => {
+    it('should produce a message successfully', async () => {
+      const dto: ProduceMessageDto = {
+        topic: 'test-topic',
+        key: 'test-key',
+        value: { test: 'data' },
+        headers: { correlationId: '123' },
+      };
+
+      const expectedResult = {
+        success: true,
+        messageId: 'msg-123',
+        topic: 'test-topic',
+        timestamp: new Date().toISOString(),
+      };
+
+      jest.spyOn(producerService, 'produce').mockResolvedValue(expectedResult);
+
+      const result = await controller.produce(dto);
+
+      expect(result).toEqual(expectedResult);
+      expect(producerService.produce).toHaveBeenCalledWith(
+        dto.topic,
+        dto.value,
+        dto.key,
+        dto.headers,
+      );
+    });
+  });
+
+  describe('GET /api/kafka', () => {
+    it('should return all messages', () => {
+      const mockEvents: KafkaEvent[] = [
+        {
+          id: 'msg-1',
+          topic: 'test-topic',
+          partition: 0,
+          offset: '100',
+          value: { test: 'data1' },
+          timestamp: new Date().toISOString(),
+          status: 'processed',
+        },
+        {
+          id: 'msg-2',
+          topic: 'test-topic',
+          partition: 0,
+          offset: '101',
+          value: { test: 'data2' },
+          timestamp: new Date().toISOString(),
+          status: 'processed',
+        },
+      ];
+
+      jest.spyOn(eventStorage, 'getAllEvents').mockReturnValue(mockEvents);
+
+      const result = controller.getMessages();
+
+      expect(result).toEqual(mockEvents);
+      expect(eventStorage.getAllEvents).toHaveBeenCalled();
+    });
+
+    it('should filter messages by topic', () => {
+      const mockEvents: KafkaEvent[] = [
+        {
+          id: 'msg-1',
+          topic: 'specific-topic',
+          partition: 0,
+          offset: '100',
+          value: { test: 'data' },
+          timestamp: new Date().toISOString(),
+          status: 'processed',
+        },
+      ];
+
+      jest.spyOn(eventStorage, 'getEventsByTopic').mockReturnValue(mockEvents);
+
+      const result = controller.getMessages('specific-topic');
+
+      expect(result).toEqual(mockEvents);
+      expect(eventStorage.getEventsByTopic).toHaveBeenCalledWith('specific-topic');
+    });
+
+    it('should filter messages by status', () => {
+      const allEvents: KafkaEvent[] = [
+        {
+          id: 'msg-1',
+          topic: 'test-topic',
+          partition: 0,
+          offset: '100',
+          value: { test: 'data1' },
+          timestamp: new Date().toISOString(),
+          status: 'processed',
+        },
+        {
+          id: 'msg-2',
+          topic: 'test-topic',
+          partition: 0,
+          offset: '101',
+          value: { test: 'data2' },
+          timestamp: new Date().toISOString(),
+          status: 'failed',
+        },
+      ];
+
+      jest.spyOn(eventStorage, 'getAllEvents').mockReturnValue(allEvents);
+
+      const result = controller.getMessages(undefined, 'processed');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].status).toBe('processed');
+    });
+
+    it('should limit the number of messages', () => {
+      const mockEvents: KafkaEvent[] = Array.from({ length: 10 }, (_, i) => ({
+        id: `msg-${i}`,
+        topic: 'test-topic',
+        partition: 0,
+        offset: String(i),
+        value: { test: `data${i}` },
+        timestamp: new Date().toISOString(),
+        status: 'processed' as const,
+      }));
+
+      jest.spyOn(eventStorage, 'getAllEvents').mockReturnValue(mockEvents);
+
+      const result = controller.getMessages(undefined, undefined, '5');
+
+      expect(result).toHaveLength(5);
+    });
+  });
+
+  describe('GET /api/kafka/stats', () => {
+    it('should return statistics', () => {
+      const mockStats = {
+        total: 100,
+        byTopic: { 'topic-a': 50, 'topic-b': 50 },
+        byStatus: { pending: 10, processed: 80, failed: 10 },
+      };
+
+      const mockTopics = ['topic-a', 'topic-b', 'topic-c'];
+
+      jest.spyOn(eventStorage, 'getStats').mockReturnValue(mockStats);
+      jest.spyOn(consumerService, 'getSubscribedTopics').mockReturnValue(mockTopics);
+
+      const result = controller.getStats();
+
+      expect(result).toEqual({
+        ...mockStats,
+        subscribedTopics: mockTopics,
+      });
+    });
+  });
+
+  describe('GET /api/kafka/topics', () => {
+    it('should return subscribed topics', () => {
+      const mockTopics = ['topic-1', 'topic-2', 'topic-3'];
+      jest.spyOn(consumerService, 'getSubscribedTopics').mockReturnValue(mockTopics);
+
+      const result = controller.getTopics();
+
+      expect(result).toEqual({ topics: mockTopics });
+    });
+  });
+
+  describe('GET /api/kafka/:id', () => {
+    it('should return a message by ID', () => {
+      const mockEvent: KafkaEvent = {
+        id: 'msg-123',
+        topic: 'test-topic',
+        partition: 0,
+        offset: '100',
+        value: { test: 'data' },
+        timestamp: new Date().toISOString(),
+        status: 'processed',
+      };
+
+      jest.spyOn(eventStorage, 'getEvent').mockReturnValue(mockEvent);
+
+      const result = controller.getMessage('msg-123');
+
+      expect(result).toEqual(mockEvent);
+    });
+
+    it('should return 404 for non-existent message', () => {
+      jest.spyOn(eventStorage, 'getEvent').mockReturnValue(undefined);
+
+      const result = controller.getMessage('non-existent');
+
+      expect(result).toEqual({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: 'Message not found',
+      });
+    });
+  });
+
+  describe('POST /api/kafka/produce-batch', () => {
+    it('should produce multiple messages', async () => {
+      const dto = {
+        topic: 'test-topic',
+        messages: [
+          { key: 'key1', value: { data: 'message1' } },
+          { key: 'key2', value: { data: 'message2' } },
+        ],
+      };
+
+      const expectedResults = [
+        {
+          success: true,
+          messageId: 'msg-1',
+          topic: 'test-topic',
+          timestamp: new Date().toISOString(),
+        },
+        {
+          success: true,
+          messageId: 'msg-2',
+          topic: 'test-topic',
+          timestamp: new Date().toISOString(),
+        },
+      ];
+
+      jest.spyOn(producerService, 'produceMany').mockResolvedValue(expectedResults);
+
+      const result = await controller.produceBatch(dto);
+
+      expect(result).toEqual(expectedResults);
+      expect(producerService.produceMany).toHaveBeenCalledWith(dto.topic, dto.messages);
+    });
+  });
+
+  describe('POST /api/kafka/subscribe', () => {
+    it('should subscribe to a new topic', async () => {
+      const dto = { topic: 'new-topic' };
+      const mockTopics = ['topic-1', 'topic-2', 'new-topic'];
+
+      jest.spyOn(consumerService, 'subscribeToTopic').mockResolvedValue(undefined);
+      jest.spyOn(consumerService, 'getSubscribedTopics').mockReturnValue(mockTopics);
+
+      const result = await controller.subscribe(dto);
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Subscribed to topic: new-topic',
+        subscribedTopics: mockTopics,
+      });
+      expect(consumerService.subscribeToTopic).toHaveBeenCalledWith('new-topic');
+    });
+  });
+});

--- a/src/kafka/controllers/kafka.controller.ts
+++ b/src/kafka/controllers/kafka.controller.ts
@@ -1,0 +1,235 @@
+import { Controller, Post, Get, Body, Param, Query, HttpStatus, HttpCode } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiParam } from '@nestjs/swagger';
+import { KafkaProducerService } from '../services/kafka-producer.service';
+import { KafkaConsumerService } from '../services/kafka-consumer.service';
+import { EventStorageService } from '../services/event-storage.service';
+import { ProduceMessageDto } from '../dto/produce-message.dto';
+import { KafkaMessageDto } from '../dto/kafka-message.dto';
+
+@ApiTags('kafka')
+@Controller('api/kafka')
+export class KafkaController {
+  constructor(
+    private readonly producerService: KafkaProducerService,
+    private readonly consumerService: KafkaConsumerService,
+    private readonly eventStorage: EventStorageService,
+  ) {}
+
+  @Post('produce')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Produce a message to Kafka',
+    description: 'Send a message to a specified Kafka topic',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Message produced successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean', example: true },
+        messageId: { type: 'string', example: 'msg-123-456' },
+        topic: { type: 'string', example: 'user-events' },
+        timestamp: { type: 'string', example: '2024-01-01T00:00:00Z' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Failed to produce message',
+  })
+  async produce(@Body() dto: ProduceMessageDto) {
+    return this.producerService.produce(dto.topic, dto.value, dto.key, dto.headers);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get all consumed messages',
+    description: 'Retrieve all messages that have been consumed from Kafka',
+  })
+  @ApiQuery({
+    name: 'topic',
+    required: false,
+    description: 'Filter messages by topic',
+    example: 'user-events',
+  })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ['pending', 'processed', 'failed'],
+    description: 'Filter messages by status',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: 'number',
+    description: 'Limit the number of messages returned',
+    example: 10,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Messages retrieved successfully',
+    type: [KafkaMessageDto],
+  })
+  getMessages(
+    @Query('topic') topic?: string,
+    @Query('status') status?: 'pending' | 'processed' | 'failed',
+    @Query('limit') limit?: string,
+  ): KafkaMessageDto[] {
+    let messages = topic
+      ? this.eventStorage.getEventsByTopic(topic)
+      : this.eventStorage.getAllEvents();
+
+    if (status) {
+      messages = messages.filter((m) => m.status === status);
+    }
+
+    if (limit) {
+      const limitNum = parseInt(limit, 10);
+      if (!isNaN(limitNum) && limitNum > 0) {
+        messages = messages.slice(0, limitNum);
+      }
+    }
+
+    return messages;
+  }
+
+  @Get('stats')
+  @ApiOperation({
+    summary: 'Get Kafka statistics',
+    description: 'Retrieve statistics about produced and consumed messages',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Statistics retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        total: { type: 'number', example: 100 },
+        byTopic: {
+          type: 'object',
+          example: { 'user-events': 50, 'system-events': 30 },
+        },
+        byStatus: {
+          type: 'object',
+          example: { pending: 10, processed: 80, failed: 10 },
+        },
+        subscribedTopics: {
+          type: 'array',
+          items: { type: 'string' },
+          example: ['user-events', 'system-events'],
+        },
+      },
+    },
+  })
+  getStats() {
+    const stats = this.eventStorage.getStats();
+    const subscribedTopics = this.consumerService.getSubscribedTopics();
+
+    return {
+      ...stats,
+      subscribedTopics,
+    };
+  }
+
+  @Get('topics')
+  @ApiOperation({
+    summary: 'Get subscribed topics',
+    description: 'Retrieve the list of topics the consumer is subscribed to',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Topics retrieved successfully',
+    type: [String],
+  })
+  getTopics() {
+    return {
+      topics: this.consumerService.getSubscribedTopics(),
+    };
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get message by ID',
+    description: 'Retrieve a specific message by its ID',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Message ID',
+    example: 'msg-123-456',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Message retrieved successfully',
+    type: KafkaMessageDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Message not found',
+  })
+  getMessage(@Param('id') id: string) {
+    const message = this.eventStorage.getEvent(id);
+    if (!message) {
+      return {
+        statusCode: HttpStatus.NOT_FOUND,
+        message: 'Message not found',
+      };
+    }
+    return message;
+  }
+
+  @Post('produce-batch')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Produce multiple messages to Kafka',
+    description: 'Send multiple messages to a specified Kafka topic',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Messages produced successfully',
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          success: { type: 'boolean' },
+          messageId: { type: 'string' },
+          topic: { type: 'string' },
+          timestamp: { type: 'string' },
+        },
+      },
+    },
+  })
+  async produceBatch(
+    @Body()
+    dto: {
+      topic: string;
+      messages: Array<{ key?: string; value: any; headers?: Record<string, string> }>;
+    },
+  ) {
+    return this.producerService.produceMany(dto.topic, dto.messages);
+  }
+
+  @Post('subscribe')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Subscribe to a new topic',
+    description: 'Subscribe the consumer to a new Kafka topic',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Successfully subscribed to topic',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Failed to subscribe to topic',
+  })
+  async subscribe(@Body() dto: { topic: string }) {
+    await this.consumerService.subscribeToTopic(dto.topic);
+    return {
+      success: true,
+      message: `Subscribed to topic: ${dto.topic}`,
+      subscribedTopics: this.consumerService.getSubscribedTopics(),
+    };
+  }
+}

--- a/src/kafka/dto/kafka-message.dto.ts
+++ b/src/kafka/dto/kafka-message.dto.ts
@@ -1,0 +1,60 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class KafkaMessageDto {
+  @ApiProperty({
+    description: 'Unique identifier for the message',
+    example: 'msg-123-456',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'The topic the message was sent to or received from',
+    example: 'user-events',
+  })
+  topic: string;
+
+  @ApiProperty({
+    description: 'The partition number',
+    example: 0,
+  })
+  partition: number;
+
+  @ApiProperty({
+    description: 'The offset of the message',
+    example: '12345',
+  })
+  offset: string;
+
+  @ApiProperty({
+    description: 'The message key',
+    example: 'user-123',
+    required: false,
+  })
+  key?: string;
+
+  @ApiProperty({
+    description: 'The message value/payload',
+    example: { eventType: 'USER_CREATED', userId: '123' },
+  })
+  value: any;
+
+  @ApiProperty({
+    description: 'Message headers',
+    example: { correlationId: 'abc-123' },
+    required: false,
+  })
+  headers?: Record<string, string>;
+
+  @ApiProperty({
+    description: 'Timestamp when the message was created',
+    example: '2024-01-01T00:00:00Z',
+  })
+  timestamp: string;
+
+  @ApiProperty({
+    description: 'Processing status',
+    enum: ['pending', 'processed', 'failed'],
+    example: 'processed',
+  })
+  status: 'pending' | 'processed' | 'failed';
+}

--- a/src/kafka/dto/produce-message.dto.ts
+++ b/src/kafka/dto/produce-message.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsOptional, IsObject } from 'class-validator';
+
+export class ProduceMessageDto {
+  @ApiProperty({
+    description: 'The topic to send the message to',
+    example: 'user-events',
+  })
+  @IsString()
+  @IsNotEmpty()
+  topic: string;
+
+  @ApiProperty({
+    description: 'The message key for partitioning',
+    example: 'user-123',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  key?: string;
+
+  @ApiProperty({
+    description: 'The message payload',
+    example: { eventType: 'USER_CREATED', userId: '123', timestamp: '2024-01-01T00:00:00Z' },
+  })
+  @IsObject()
+  @IsNotEmpty()
+  value: Record<string, any>;
+
+  @ApiProperty({
+    description: 'Optional headers for the message',
+    example: { correlationId: 'abc-123', source: 'api' },
+    required: false,
+  })
+  @IsObject()
+  @IsOptional()
+  headers?: Record<string, string>;
+}

--- a/src/kafka/interfaces/kafka-event.interface.ts
+++ b/src/kafka/interfaces/kafka-event.interface.ts
@@ -1,0 +1,21 @@
+export interface KafkaEvent {
+  id: string;
+  topic: string;
+  partition: number;
+  offset: string;
+  key?: string;
+  value: any;
+  headers?: Record<string, string>;
+  timestamp: string;
+  status: 'pending' | 'processed' | 'failed';
+}
+
+export interface ProducerResult {
+  success: boolean;
+  messageId: string;
+  topic: string;
+  partition?: number;
+  offset?: string;
+  timestamp: string;
+  error?: string;
+}

--- a/src/kafka/kafka.module.ts
+++ b/src/kafka/kafka.module.ts
@@ -1,0 +1,36 @@
+import { Module } from '@nestjs/common';
+import { ClientsModule, Transport } from '@nestjs/microservices';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { KafkaController } from './controllers/kafka.controller';
+import { KafkaProducerService } from './services/kafka-producer.service';
+import { KafkaConsumerService } from './services/kafka-consumer.service';
+import { EventStorageService } from './services/event-storage.service';
+
+@Module({
+  imports: [
+    ConfigModule,
+    ClientsModule.registerAsync([
+      {
+        name: 'KAFKA_SERVICE',
+        imports: [ConfigModule],
+        useFactory: (configService: ConfigService) => ({
+          transport: Transport.KAFKA,
+          options: {
+            client: {
+              clientId: configService.get('KAFKA_CLIENT_ID', 'core-pipeline'),
+              brokers: [configService.get('KAFKA_BROKER', 'localhost:9092')],
+            },
+            consumer: {
+              groupId: configService.get('KAFKA_CONSUMER_GROUP', 'core-pipeline-group'),
+            },
+          },
+        }),
+        inject: [ConfigService],
+      },
+    ]),
+  ],
+  controllers: [KafkaController],
+  providers: [KafkaProducerService, KafkaConsumerService, EventStorageService],
+  exports: [KafkaProducerService, KafkaConsumerService],
+})
+export class KafkaModule {}

--- a/src/kafka/services/event-storage.service.spec.ts
+++ b/src/kafka/services/event-storage.service.spec.ts
@@ -1,0 +1,253 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventStorageService } from './event-storage.service';
+import { KafkaEvent } from '../interfaces/kafka-event.interface';
+
+describe('EventStorageService', () => {
+  let service: EventStorageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EventStorageService],
+    }).compile();
+
+    service = module.get<EventStorageService>(EventStorageService);
+  });
+
+  afterEach(() => {
+    service.clearEvents();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('addEvent', () => {
+    it('should add an event to storage', () => {
+      const event: KafkaEvent = {
+        id: 'test-1',
+        topic: 'test-topic',
+        partition: 0,
+        offset: '100',
+        value: { test: 'data' },
+        timestamp: new Date().toISOString(),
+        status: 'processed',
+      };
+
+      service.addEvent(event);
+      expect(service.getEvent('test-1')).toEqual(event);
+    });
+
+    it('should track events by topic', () => {
+      const event1: KafkaEvent = {
+        id: 'test-1',
+        topic: 'topic-a',
+        partition: 0,
+        offset: '100',
+        value: { test: 'data1' },
+        timestamp: new Date().toISOString(),
+        status: 'processed',
+      };
+
+      const event2: KafkaEvent = {
+        id: 'test-2',
+        topic: 'topic-a',
+        partition: 0,
+        offset: '101',
+        value: { test: 'data2' },
+        timestamp: new Date().toISOString(),
+        status: 'processed',
+      };
+
+      const event3: KafkaEvent = {
+        id: 'test-3',
+        topic: 'topic-b',
+        partition: 0,
+        offset: '102',
+        value: { test: 'data3' },
+        timestamp: new Date().toISOString(),
+        status: 'processed',
+      };
+
+      service.addEvent(event1);
+      service.addEvent(event2);
+      service.addEvent(event3);
+
+      const topicAEvents = service.getEventsByTopic('topic-a');
+      expect(topicAEvents).toHaveLength(2);
+      expect(topicAEvents.map((e) => e.id)).toContain('test-1');
+      expect(topicAEvents.map((e) => e.id)).toContain('test-2');
+
+      const topicBEvents = service.getEventsByTopic('topic-b');
+      expect(topicBEvents).toHaveLength(1);
+      expect(topicBEvents[0].id).toBe('test-3');
+    });
+  });
+
+  describe('getEvent', () => {
+    it('should return undefined for non-existent event', () => {
+      expect(service.getEvent('non-existent')).toBeUndefined();
+    });
+
+    it('should return the correct event', () => {
+      const event: KafkaEvent = {
+        id: 'test-1',
+        topic: 'test-topic',
+        partition: 0,
+        offset: '100',
+        value: { test: 'data' },
+        timestamp: new Date().toISOString(),
+        status: 'processed',
+      };
+
+      service.addEvent(event);
+      expect(service.getEvent('test-1')).toEqual(event);
+    });
+  });
+
+  describe('getAllEvents', () => {
+    it('should return all events sorted by timestamp', () => {
+      const now = Date.now();
+      const event1: KafkaEvent = {
+        id: 'test-1',
+        topic: 'test-topic',
+        partition: 0,
+        offset: '100',
+        value: { test: 'data1' },
+        timestamp: new Date(now - 2000).toISOString(),
+        status: 'processed',
+      };
+
+      const event2: KafkaEvent = {
+        id: 'test-2',
+        topic: 'test-topic',
+        partition: 0,
+        offset: '101',
+        value: { test: 'data2' },
+        timestamp: new Date(now).toISOString(),
+        status: 'processed',
+      };
+
+      const event3: KafkaEvent = {
+        id: 'test-3',
+        topic: 'test-topic',
+        partition: 0,
+        offset: '102',
+        value: { test: 'data3' },
+        timestamp: new Date(now - 1000).toISOString(),
+        status: 'processed',
+      };
+
+      service.addEvent(event1);
+      service.addEvent(event2);
+      service.addEvent(event3);
+
+      const allEvents = service.getAllEvents();
+      expect(allEvents).toHaveLength(3);
+      expect(allEvents[0].id).toBe('test-2');
+      expect(allEvents[1].id).toBe('test-3');
+      expect(allEvents[2].id).toBe('test-1');
+    });
+  });
+
+  describe('updateEventStatus', () => {
+    it('should update event status', () => {
+      const event: KafkaEvent = {
+        id: 'test-1',
+        topic: 'test-topic',
+        partition: 0,
+        offset: '100',
+        value: { test: 'data' },
+        timestamp: new Date().toISOString(),
+        status: 'pending',
+      };
+
+      service.addEvent(event);
+      service.updateEventStatus('test-1', 'processed');
+
+      const updatedEvent = service.getEvent('test-1');
+      expect(updatedEvent?.status).toBe('processed');
+    });
+
+    it('should not throw error for non-existent event', () => {
+      expect(() => {
+        service.updateEventStatus('non-existent', 'processed');
+      }).not.toThrow();
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return correct statistics', () => {
+      const events: KafkaEvent[] = [
+        {
+          id: 'test-1',
+          topic: 'topic-a',
+          partition: 0,
+          offset: '100',
+          value: { test: 'data1' },
+          timestamp: new Date().toISOString(),
+          status: 'processed',
+        },
+        {
+          id: 'test-2',
+          topic: 'topic-a',
+          partition: 0,
+          offset: '101',
+          value: { test: 'data2' },
+          timestamp: new Date().toISOString(),
+          status: 'pending',
+        },
+        {
+          id: 'test-3',
+          topic: 'topic-b',
+          partition: 0,
+          offset: '102',
+          value: { test: 'data3' },
+          timestamp: new Date().toISOString(),
+          status: 'failed',
+        },
+      ];
+
+      events.forEach((event) => service.addEvent(event));
+
+      const stats = service.getStats();
+      expect(stats.total).toBe(3);
+      expect(stats.byTopic['topic-a']).toBe(2);
+      expect(stats.byTopic['topic-b']).toBe(1);
+      expect(stats.byStatus.processed).toBe(1);
+      expect(stats.byStatus.pending).toBe(1);
+      expect(stats.byStatus.failed).toBe(1);
+    });
+
+    it('should return empty stats when no events', () => {
+      const stats = service.getStats();
+      expect(stats.total).toBe(0);
+      expect(stats.byTopic).toEqual({});
+      expect(stats.byStatus).toEqual({
+        pending: 0,
+        processed: 0,
+        failed: 0,
+      });
+    });
+  });
+
+  describe('clearEvents', () => {
+    it('should clear all events', () => {
+      const event: KafkaEvent = {
+        id: 'test-1',
+        topic: 'test-topic',
+        partition: 0,
+        offset: '100',
+        value: { test: 'data' },
+        timestamp: new Date().toISOString(),
+        status: 'processed',
+      };
+
+      service.addEvent(event);
+      expect(service.getAllEvents()).toHaveLength(1);
+
+      service.clearEvents();
+      expect(service.getAllEvents()).toHaveLength(0);
+      expect(service.getStats().total).toBe(0);
+    });
+  });
+});

--- a/src/kafka/services/event-storage.service.ts
+++ b/src/kafka/services/event-storage.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@nestjs/common';
+import { KafkaEvent } from '../interfaces/kafka-event.interface';
+
+@Injectable()
+export class EventStorageService {
+  private events: Map<string, KafkaEvent> = new Map();
+  private eventsByTopic: Map<string, Set<string>> = new Map();
+
+  addEvent(event: KafkaEvent): void {
+    this.events.set(event.id, event);
+
+    if (!this.eventsByTopic.has(event.topic)) {
+      this.eventsByTopic.set(event.topic, new Set());
+    }
+    this.eventsByTopic.get(event.topic)?.add(event.id);
+  }
+
+  getEvent(id: string): KafkaEvent | undefined {
+    return this.events.get(id);
+  }
+
+  getAllEvents(): KafkaEvent[] {
+    return Array.from(this.events.values()).sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    );
+  }
+
+  getEventsByTopic(topic: string): KafkaEvent[] {
+    const eventIds = this.eventsByTopic.get(topic);
+    if (!eventIds) return [];
+
+    return Array.from(eventIds)
+      .map((id) => this.events.get(id))
+      .filter((event): event is KafkaEvent => event !== undefined)
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+  }
+
+  updateEventStatus(id: string, status: 'pending' | 'processed' | 'failed'): void {
+    const event = this.events.get(id);
+    if (event) {
+      event.status = status;
+    }
+  }
+
+  clearEvents(): void {
+    this.events.clear();
+    this.eventsByTopic.clear();
+  }
+
+  getStats(): { total: number; byTopic: Record<string, number>; byStatus: Record<string, number> } {
+    const stats = {
+      total: this.events.size,
+      byTopic: {} as Record<string, number>,
+      byStatus: {
+        pending: 0,
+        processed: 0,
+        failed: 0,
+      },
+    };
+
+    for (const [topic, eventIds] of this.eventsByTopic.entries()) {
+      stats.byTopic[topic] = eventIds.size;
+    }
+
+    for (const event of this.events.values()) {
+      stats.byStatus[event.status]++;
+    }
+
+    return stats;
+  }
+}

--- a/src/kafka/services/kafka-consumer.service.spec.ts
+++ b/src/kafka/services/kafka-consumer.service.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { KafkaConsumerService } from './kafka-consumer.service';
+import { EventStorageService } from './event-storage.service';
+
+jest.mock('kafkajs', () => ({
+  Kafka: jest.fn().mockImplementation(() => ({
+    consumer: jest.fn().mockImplementation(() => ({
+      connect: jest.fn().mockResolvedValue(undefined),
+      subscribe: jest.fn().mockResolvedValue(undefined),
+      run: jest.fn().mockResolvedValue(undefined),
+    })),
+  })),
+}));
+
+describe('KafkaConsumerService', () => {
+  let service: KafkaConsumerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KafkaConsumerService,
+        EventStorageService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockImplementation((key: string, defaultValue?: any) => {
+              const config: Record<string, any> = {
+                KAFKA_CLIENT_ID: 'test-client',
+                KAFKA_BROKER: 'localhost:9092',
+                KAFKA_CONSUMER_GROUP: 'test-group',
+              };
+              return config[key] || defaultValue;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<KafkaConsumerService>(KafkaConsumerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('subscribeToTopic', () => {
+    it('should subscribe to a new topic', async () => {
+      const topic = 'new-topic';
+
+      await service.subscribeToTopic(topic);
+
+      const subscribedTopics = service.getSubscribedTopics();
+      expect(subscribedTopics).toContain(topic);
+    });
+
+    it('should not subscribe to the same topic twice', async () => {
+      const topic = 'duplicate-topic';
+
+      await service.subscribeToTopic(topic);
+      await service.subscribeToTopic(topic);
+
+      const subscribedTopics = service.getSubscribedTopics();
+      const topicCount = subscribedTopics.filter((t) => t === topic).length;
+      expect(topicCount).toBe(1);
+    });
+  });
+
+  describe('getSubscribedTopics', () => {
+    it('should return list of subscribed topics', async () => {
+      const topics = ['topic1', 'topic2', 'topic3'];
+
+      for (const topic of topics) {
+        await service.subscribeToTopic(topic);
+      }
+
+      const subscribedTopics = service.getSubscribedTopics();
+      expect(subscribedTopics).toEqual(expect.arrayContaining(topics));
+    });
+  });
+});

--- a/src/kafka/services/kafka-consumer.service.ts
+++ b/src/kafka/services/kafka-consumer.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { Kafka, Consumer, EachMessagePayload } from 'kafkajs';
+import { ConfigService } from '@nestjs/config';
+import { EventStorageService } from './event-storage.service';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class KafkaConsumerService implements OnModuleInit {
+  private readonly logger = new Logger(KafkaConsumerService.name);
+  private kafka: Kafka;
+  private consumer: Consumer;
+  private readonly subscribedTopics: Set<string> = new Set();
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly eventStorage: EventStorageService,
+  ) {
+    this.kafka = new Kafka({
+      clientId: this.configService.get('KAFKA_CLIENT_ID', 'core-pipeline'),
+      brokers: [this.configService.get('KAFKA_BROKER', 'localhost:9092')],
+    });
+
+    this.consumer = this.kafka.consumer({
+      groupId: this.configService.get('KAFKA_CONSUMER_GROUP', 'core-pipeline-group'),
+    });
+  }
+
+  async onModuleInit() {
+    try {
+      await this.consumer.connect();
+      this.logger.log('Kafka consumer connected');
+
+      const defaultTopics = ['user-events', 'system-events', 'showcase-events'];
+      for (const topic of defaultTopics) {
+        await this.subscribeToTopic(topic);
+      }
+
+      await this.consumer.run({
+        eachMessage: async (payload: EachMessagePayload) => {
+          await this.handleMessage(payload);
+        },
+      });
+    } catch (error) {
+      this.logger.error('Failed to initialize Kafka consumer', error);
+    }
+  }
+
+  async subscribeToTopic(topic: string): Promise<void> {
+    if (this.subscribedTopics.has(topic)) {
+      this.logger.log(`Already subscribed to topic: ${topic}`);
+      return;
+    }
+
+    try {
+      await this.consumer.subscribe({ topic, fromBeginning: false });
+      this.subscribedTopics.add(topic);
+      this.logger.log(`Subscribed to topic: ${topic}`);
+    } catch (error) {
+      this.logger.error(`Failed to subscribe to topic: ${topic}`, error);
+      throw error;
+    }
+  }
+
+  private async handleMessage({ topic, partition, message }: EachMessagePayload): Promise<void> {
+    const messageId = randomUUID();
+    const timestamp = new Date().toISOString();
+
+    try {
+      const key = message.key?.toString();
+      const value = message.value ? JSON.parse(message.value.toString()) : null;
+      const headers = this.parseHeaders(message.headers as Record<string, Buffer | undefined>);
+
+      this.logger.log(`Received message from topic: ${topic}`, {
+        messageId,
+        partition,
+        offset: message.offset,
+        key,
+      });
+
+      const kafkaEvent = {
+        id: messageId,
+        topic,
+        partition,
+        offset: message.offset,
+        key,
+        value,
+        headers,
+        timestamp,
+        status: 'processed' as const,
+      };
+
+      this.eventStorage.addEvent(kafkaEvent);
+
+      this.processBusinessLogic(topic, value, headers);
+    } catch (error) {
+      this.logger.error(`Failed to process message from topic: ${topic}`, error);
+
+      const kafkaEvent = {
+        id: messageId,
+        topic,
+        partition,
+        offset: message.offset,
+        key: message.key?.toString(),
+        value: message.value?.toString(),
+        headers: {},
+        timestamp,
+        status: 'failed' as const,
+      };
+
+      this.eventStorage.addEvent(kafkaEvent);
+    }
+  }
+
+  private parseHeaders(headers?: Record<string, Buffer | undefined>): Record<string, string> {
+    if (!headers) return {};
+
+    const parsed: Record<string, string> = {};
+    for (const [key, value] of Object.entries(headers)) {
+      if (value) {
+        parsed[key] = value.toString();
+      }
+    }
+    return parsed;
+  }
+
+  private processBusinessLogic(topic: string, value: any, headers: Record<string, string>): void {
+    switch (topic) {
+      case 'user-events':
+        this.handleUserEvent(value, headers);
+        break;
+      case 'system-events':
+        this.handleSystemEvent(value, headers);
+        break;
+      case 'showcase-events':
+        this.handleShowcaseEvent(value, headers);
+        break;
+      default:
+        this.logger.log(`Received message from topic: ${topic}`, value);
+    }
+  }
+
+  private handleUserEvent(event: any, headers: Record<string, string>): void {
+    this.logger.log('Processing user event', { event, headers });
+  }
+
+  private handleSystemEvent(event: any, headers: Record<string, string>): void {
+    this.logger.log('Processing system event', { event, headers });
+  }
+
+  private handleShowcaseEvent(event: any, headers: Record<string, string>): void {
+    this.logger.log('Processing showcase event', { event, headers });
+  }
+
+  getSubscribedTopics(): string[] {
+    return Array.from(this.subscribedTopics);
+  }
+}

--- a/src/kafka/services/kafka-producer.service.spec.ts
+++ b/src/kafka/services/kafka-producer.service.spec.ts
@@ -1,0 +1,154 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClientKafka } from '@nestjs/microservices';
+import { KafkaProducerService } from './kafka-producer.service';
+import { EventStorageService } from './event-storage.service';
+import { of, throwError } from 'rxjs';
+
+describe('KafkaProducerService', () => {
+  let service: KafkaProducerService;
+  let kafkaClient: ClientKafka;
+  let eventStorage: EventStorageService;
+
+  beforeEach(async () => {
+    const mockKafkaClient = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      emit: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KafkaProducerService,
+        EventStorageService,
+        {
+          provide: 'KAFKA_SERVICE',
+          useValue: mockKafkaClient,
+        },
+      ],
+    }).compile();
+
+    service = module.get<KafkaProducerService>(KafkaProducerService);
+    kafkaClient = module.get<ClientKafka>('KAFKA_SERVICE');
+    eventStorage = module.get<EventStorageService>(EventStorageService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('onModuleInit', () => {
+    it('should connect to Kafka on module init', async () => {
+      await service.onModuleInit();
+      expect(kafkaClient.connect).toHaveBeenCalled();
+    });
+  });
+
+  describe('produce', () => {
+    it('should successfully produce a message', async () => {
+      const topic = 'test-topic';
+      const message = { test: 'data' };
+      const key = 'test-key';
+      const headers = { correlationId: '123' };
+
+      jest.spyOn(kafkaClient, 'emit').mockReturnValue(of(undefined));
+      jest.spyOn(eventStorage, 'addEvent');
+
+      const result = await service.produce(topic, message, key, headers);
+
+      expect(result.success).toBe(true);
+      expect(result.topic).toBe(topic);
+      expect(result.messageId).toBeDefined();
+      expect(result.timestamp).toBeDefined();
+      expect(eventStorage.addEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          topic,
+          value: message,
+          key,
+          headers,
+          status: 'processed',
+        }),
+      );
+    });
+
+    it('should handle production failure', async () => {
+      const topic = 'test-topic';
+      const message = { test: 'data' };
+      const error = new Error('Kafka error');
+
+      jest.spyOn(kafkaClient, 'emit').mockReturnValue(throwError(() => error));
+      jest.spyOn(eventStorage, 'addEvent');
+
+      const result = await service.produce(topic, message);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Kafka error');
+      expect(eventStorage.addEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          topic,
+          value: message,
+          status: 'failed',
+        }),
+      );
+    });
+
+    it('should produce message without key and headers', async () => {
+      const topic = 'test-topic';
+      const message = { test: 'data' };
+
+      jest.spyOn(kafkaClient, 'emit').mockReturnValue(of(undefined));
+
+      const result = await service.produce(topic, message);
+
+      expect(result.success).toBe(true);
+      expect(kafkaClient.emit).toHaveBeenCalledWith(
+        topic,
+        expect.objectContaining({
+          value: message,
+        }),
+      );
+    });
+  });
+
+  describe('produceMany', () => {
+    it('should produce multiple messages', async () => {
+      const topic = 'test-topic';
+      const messages = [
+        { key: 'key1', value: { data: 'message1' } },
+        { key: 'key2', value: { data: 'message2' } },
+        { key: 'key3', value: { data: 'message3' } },
+      ];
+
+      jest.spyOn(kafkaClient, 'emit').mockReturnValue(of(undefined));
+
+      const results = await service.produceMany(topic, messages);
+
+      expect(results).toHaveLength(3);
+      expect(results.every((r) => r.success)).toBe(true);
+      expect(results.every((r) => r.topic === topic)).toBe(true);
+    });
+
+    it('should handle partial failure in batch production', async () => {
+      const topic = 'test-topic';
+      const messages = [
+        { key: 'key1', value: { data: 'message1' } },
+        { key: 'key2', value: { data: 'message2' } },
+      ];
+
+      let callCount = 0;
+      jest.spyOn(kafkaClient, 'emit').mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return of(undefined);
+        } else {
+          return throwError(() => new Error('Kafka error'));
+        }
+      });
+
+      const results = await service.produceMany(topic, messages);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].success).toBe(true);
+      expect(results[1].success).toBe(false);
+      expect(results[1].error).toBe('Kafka error');
+    });
+  });
+});

--- a/src/kafka/services/kafka-producer.service.ts
+++ b/src/kafka/services/kafka-producer.service.ts
@@ -1,0 +1,114 @@
+import { Injectable, Inject, Logger, OnModuleInit } from '@nestjs/common';
+import { ClientKafka } from '@nestjs/microservices';
+import { ProducerResult } from '../interfaces/kafka-event.interface';
+import { EventStorageService } from './event-storage.service';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class KafkaProducerService implements OnModuleInit {
+  private readonly logger = new Logger(KafkaProducerService.name);
+
+  constructor(
+    @Inject('KAFKA_SERVICE') private readonly kafkaClient: ClientKafka,
+    private readonly eventStorage: EventStorageService,
+  ) {}
+
+  async onModuleInit() {
+    await this.kafkaClient.connect();
+    this.logger.log('Kafka producer connected');
+  }
+
+  async produce(
+    topic: string,
+    message: any,
+    key?: string,
+    headers?: Record<string, string>,
+  ): Promise<ProducerResult> {
+    const messageId = randomUUID();
+    const timestamp = new Date().toISOString();
+
+    try {
+      this.logger.log(`Producing message to topic: ${topic}`, {
+        messageId,
+        key,
+        headers,
+      });
+
+      await this.kafkaClient
+        .emit(topic, {
+          key,
+          value: message,
+          headers: {
+            ...headers,
+            messageId,
+            timestamp,
+          },
+        })
+        .toPromise();
+
+      const kafkaEvent = {
+        id: messageId,
+        topic,
+        partition: 0,
+        offset: '0',
+        key,
+        value: message,
+        headers,
+        timestamp,
+        status: 'processed' as const,
+      };
+
+      this.eventStorage.addEvent(kafkaEvent);
+
+      this.logger.log(`Message produced successfully`, {
+        messageId,
+        topic,
+      });
+
+      return {
+        success: true,
+        messageId,
+        topic,
+        timestamp,
+      };
+    } catch (error) {
+      this.logger.error(`Failed to produce message to topic: ${topic}`, error);
+
+      const kafkaEvent = {
+        id: messageId,
+        topic,
+        partition: 0,
+        offset: '0',
+        key,
+        value: message,
+        headers,
+        timestamp,
+        status: 'failed' as const,
+      };
+
+      this.eventStorage.addEvent(kafkaEvent);
+
+      return {
+        success: false,
+        messageId,
+        topic,
+        timestamp,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  async produceMany(
+    topic: string,
+    messages: Array<{ key?: string; value: any; headers?: Record<string, string> }>,
+  ): Promise<ProducerResult[]> {
+    const results: ProducerResult[] = [];
+
+    for (const message of messages) {
+      const result = await this.produce(topic, message.value, message.key, message.headers);
+      results.push(result);
+    }
+
+    return results;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,18 +15,19 @@ async function bootstrap() {
 
     const config = new DocumentBuilder()
       .setTitle('Core Pipeline API')
-      .setDescription('Core Pipeline REST API with observability')
+      .setDescription('Core Pipeline REST API with observability and Kafka showcase')
       .setVersion('1.0')
       .addTag('health', 'Health check endpoints')
+      .addTag('kafka', 'Kafka showcase endpoints')
       .build();
     const document = SwaggerModule.createDocument(app, config);
-    SwaggerModule.setup('api-docs', app, document);
+    SwaggerModule.setup('swagger', app, document);
 
     const port = process.env.PORT || 3000;
     await app.listen(port);
 
     console.log(`Application is running on: http://localhost:${port}`);
-    console.log(`Swagger documentation available at: http://localhost:${port}/api-docs`);
+    console.log(`Swagger documentation available at: http://localhost:${port}/swagger`);
     console.log(`Metrics available at: http://localhost:${port}/metrics`);
   } catch (error) {
     console.error('Failed to start application:', error);


### PR DESCRIPTION
## Summary
- Moved Swagger endpoint from `/api-docs` to `/swagger` for better convention
- Added complete Kafka showcase implementation with producer/consumer capabilities
- Included Docker Compose setup with full monitoring stack

## Changes
### Swagger Enhancement
- Updated Swagger endpoint to `/swagger`
- Added Kafka tag for API documentation

### Kafka Integration
- **Producer Service**: Send messages to Kafka topics with error handling
- **Consumer Service**: Automatically consume from configured topics
- **Event Storage**: In-memory storage for message tracking
- **REST API Endpoints**:
  - `POST /api/kafka/produce` - Send messages to topics
  - `GET /api/kafka` - Retrieve messages with filtering options
  - `GET /api/kafka/stats` - View message statistics
  - `GET /api/kafka/topics` - List subscribed topics
  - `POST /api/kafka/subscribe` - Subscribe to new topics
  - `POST /api/kafka/produce-batch` - Send multiple messages

### Infrastructure
- Docker Compose configuration with:
  - Kafka & Zookeeper
  - Kafka UI for monitoring (port 8080)
  - Prometheus for metrics collection
  - Grafana for visualization
  - Jaeger for distributed tracing

### Testing
- Comprehensive test coverage for all Kafka services
- 43 tests passing
- Mocked Kafka dependencies for unit testing

## Test Plan
- [x] All unit tests passing (`npm test`)
- [x] TypeScript compilation successful (`npx tsc --noEmit`)
- [x] Linting passed (`npm run lint`)
- [x] Build successful (`npm run build`)
- [ ] Manual testing with Docker Compose
- [ ] Verify Swagger UI at `/swagger`
- [ ] Test Kafka producer endpoint
- [ ] Verify message consumption