### PR TITLE
Migrate deployment to Kubero webhook integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,22 +77,57 @@ jobs:
     needs: build-and-push
     environment:
       name: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') || (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'production' || 'development' }}
-      url: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'https://core-pipeline.theedgestory.org' || 'https://core-pipeline.dev.theedgestory.org' }}
+      url: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'https://core-pipeline.theedgestory.org' || 'https://core-pipeline-dev.theedgestory.org' }}
     permissions:
       contents: read
       deployments: write
 
     steps:
+      # Determine target environment based on trigger type and branch
+      - name: Determine deployment environment
+        id: env
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Manual trigger: use selected environment
+            ENV="${{ github.event.inputs.environment }}"
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            # Push to main branch: deploy to production
+            ENV="production"
+          elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            # Push to develop branch: deploy to development
+            ENV="development"
+          else
+            # Default to development for other branches
+            ENV="development"
+          fi
+
+          # Set environment-specific variables
+          if [[ "$ENV" == "production" ]]; then
+            BRANCH="main"
+            URL="https://core-pipeline.theedgestory.org"
+            APP_NAME="core-pipeline"
+          else
+            BRANCH="develop"
+            URL="https://core-pipeline-dev.theedgestory.org"
+            APP_NAME="core-pipeline-dev"
+          fi
+
+          echo "environment=${ENV}" >> $GITHUB_OUTPUT
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "url=${URL}" >> $GITHUB_OUTPUT
+          echo "app_name=${APP_NAME}" >> $GITHUB_OUTPUT
+          echo "Deploying to ${ENV} environment (${APP_NAME})"
+
+      # Create GitHub deployment record for tracking
       - name: Create deployment record
         id: deployment
         uses: actions/github-script@v7
         with:
           script: |
-            const isProd = (context.eventName === 'workflow_dispatch' && context.payload.inputs.environment === 'production') ||
-                          (context.eventName === 'push' && context.ref === 'refs/heads/main');
-            const environment = isProd ? 'production' : 'development';
-            const url = isProd ? 'https://core-pipeline.theedgestory.org' : 'https://core-pipeline.dev.theedgestory.org';
-            
+            const environment = '${{ steps.env.outputs.environment }}';
+            const url = '${{ steps.env.outputs.url }}';
+            const isProd = environment === 'production';
+
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -101,85 +136,98 @@ jobs:
               auto_merge: false,
               required_contexts: [],
               environment: environment,
-              description: `Deploy to ${environment}`,
+              description: `Deploy to ${environment} via Kubero`,
               production_environment: isProd
             });
-            
+
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               deployment_id: deployment.data.id,
               state: 'in_progress',
-              environment_url: url
+              environment_url: url,
+              description: 'Triggering Kubero deployment...'
             });
-            
+
             core.setOutput('deployment_id', deployment.data.id);
-            core.setOutput('environment', environment);
-            core.setOutput('url', url);
-      
-      - name: Checkout core-charts repository
-        uses: actions/checkout@v4
-        with:
-          repository: uz0/core-charts
-          token: ${{ secrets.CORE_CHARTS_PAT }}
-          path: core-charts
 
-      - name: Update image tag file
+      # Trigger Kubero deployment via webhook
+      - name: Trigger Kubero deployment
+        id: kubero
         run: |
-          cd core-charts
-          ENVIRONMENT=${{ steps.deployment.outputs.environment == 'production' && 'prod' || 'dev' }}
-          IMAGE_TAG="${{ needs.build-and-push.outputs.image-tag }}"
-          TAG_FILE="charts/core-pipeline/${ENVIRONMENT}.tag.yaml"
+          echo "Triggering Kubero deployment for ${{ steps.env.outputs.app_name }}"
 
-          # Create or update the tag file with image info
-          cat > ${TAG_FILE} << EOF
-          image:
-            tag: "${IMAGE_TAG}"
-            repository: "ghcr.io/uz0/core-pipeline"
+          # Prepare webhook payload (GitHub-style webhook format)
+          PAYLOAD=$(cat <<EOF
+          {
+            "ref": "refs/heads/${{ steps.env.outputs.branch }}",
+            "repository": {
+              "full_name": "${{ github.repository }}",
+              "clone_url": "https://github.com/${{ github.repository }}.git"
+            },
+            "after": "${{ github.sha }}",
+            "head_commit": {
+              "id": "${{ github.sha }}",
+              "message": $(echo '${{ toJSON(github.event.head_commit.message) }}' | jq -R .)
+            }
+          }
           EOF
+          )
 
-          # Show what we're updating
-          echo "Updating ${TAG_FILE} with tag: ${IMAGE_TAG}"
-          cat ${TAG_FILE}
+          # Calculate HMAC signature for webhook authentication
+          SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac '${{ secrets.KUBERO_WEBHOOK_SECRET }}' | sed 's/^.* //')
 
-          # Commit and push with retry for concurrent deployments
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add ${TAG_FILE}
-          git commit -m "Deploy to ${ENVIRONMENT}: update tag to ${IMAGE_TAG}" || echo "No changes to commit"
+          # Send webhook to Kubero
+          HTTP_CODE=$(curl -s -o /tmp/kubero_response.json -w "%{http_code}" \
+            -X POST "https://dev.theedgestory.org/api/repo/webhooks" \
+            -H "Content-Type: application/json" \
+            -H "X-Hub-Signature-256: sha256=${SIGNATURE}" \
+            -H "X-GitHub-Event: push" \
+            -d "$PAYLOAD")
 
-          # Retry push up to 5 times to handle concurrent deployments
-          MAX_RETRIES=5
-          RETRY_COUNT=0
-          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            if git push; then
-              echo "Successfully pushed changes"
-              exit 0
-            fi
+          echo "Kubero webhook response code: ${HTTP_CODE}"
 
-            RETRY_COUNT=$((RETRY_COUNT + 1))
-            echo "Push failed (attempt $RETRY_COUNT/$MAX_RETRIES), pulling latest changes..."
+          if [[ -f /tmp/kubero_response.json ]]; then
+            echo "Response body:"
+            cat /tmp/kubero_response.json
+          fi
 
-            # Pull latest changes and rebase our commit on top
-            git pull --rebase origin main
+          # Check if webhook was successful (2xx status code)
+          if [[ "$HTTP_CODE" =~ ^2[0-9]{2}$ ]]; then
+            echo "✅ Kubero deployment triggered successfully"
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Failed to trigger Kubero deployment (HTTP ${HTTP_CODE})"
+            echo "success=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
-            # Wait a bit before retrying
-            sleep $((RETRY_COUNT * 2))
-          done
-
-          echo "Failed to push after $MAX_RETRIES attempts"
-          exit 1
-
+      # Update GitHub deployment status based on webhook result
       - name: Update deployment status
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
-            const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';
+            const kuberoSuccess = '${{ steps.kubero.outputs.success }}' === 'true';
+            const jobSuccess = '${{ job.status }}' === 'success';
+
+            let state, description;
+            if (jobSuccess && kuberoSuccess) {
+              state = 'success';
+              description = 'Deployed to Kubero - check Kubero UI for deployment progress';
+            } else if (!kuberoSuccess) {
+              state = 'failure';
+              description = 'Failed to trigger Kubero webhook';
+            } else {
+              state = 'failure';
+              description = 'Deployment job failed';
+            }
+
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               deployment_id: ${{ steps.deployment.outputs.deployment_id }},
               state: state,
-              environment_url: '${{ steps.deployment.outputs.url }}'
+              environment_url: '${{ steps.env.outputs.url }}',
+              description: description
             });

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -62,7 +62,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body: `## 🚀 Deploy this branch to development: \`${branch}\`\n\n[Click here to deploy](${deployUrl})\n\n### Monitoring & Tools\n[📊 ArgoCD](https://argo.dev.theedgestory.org/) | [📈 Grafana](https://grafana.dev.theedgestory.org/) | [📨 Kafka](https://kafka.dev.theedgestory.org/) | [🔍 Status](https://status.theedgestory.org/)`
+                body: `## 🚀 Deploy this branch to development: \`${branch}\`\n\n[Click here to deploy](${deployUrl})\n\n**Note:** Deployments are now managed by Kubero. After triggering the workflow:\n1. Monitor deployment in [GitHub Actions](${deployUrl})\n2. Check deployment status in [Kubero Dashboard](https://dev.theedgestory.org)\n\n### Monitoring & Tools\n[🎛️ Kubero](https://dev.theedgestory.org) | [📊 ArgoCD](https://argo.dev.theedgestory.org/) | [📈 Grafana](https://grafana.dev.theedgestory.org/) | [📨 Kafka](https://kafka.dev.theedgestory.org/) | [🔍 Status](https://status.theedgestory.org/)`
               });
             }
             


### PR DESCRIPTION
## Summary
- Migrated from Helm charts repository updates to Kubero webhook-based deployments
- Removed dependency on separate `core-charts` repository
- Added Kubero webhook integration with HMAC authentication
- Enhanced environment detection and deployment tracking

## Changes Made

### `.github/workflows/deploy.yml`
- **Kept:** Docker image build/push to GHCR with commit SHA tags and multi-architecture support
- **Added:** Kubero webhook trigger with proper authentication
- **Added:** Environment detection logic (main → production, develop → development)
- **Removed:** All steps related to updating the `core-charts` repository
- **Improved:** Deployment status tracking and error handling

### `.github/workflows/pr-deploy.yml`
- Added Kubero dashboard link to PR deployment comments
- Updated instructions to reference Kubero deployment flow

## Deployment Flow
1. **Build:** Docker image built and pushed to `ghcr.io/uz0/core-pipeline:main-{sha}`
2. **Trigger:** Webhook sent to Kubero with GitHub-style payload
3. **Deploy:** Kubero pulls image and deploys to appropriate environment

## Environment Mapping
- `main` branch → Production (`core-pipeline.theedgestory.org`)
- `develop` branch → Development (`core-pipeline-dev.theedgestory.org`)
- Manual trigger → User-selected environment

## Required Setup
Before merging, add the following GitHub secret:
- **Name:** `KUBERO_WEBHOOK_SECRET`
- **Value:** `1?F4Sqbqahix1uG7d7r8`

## Testing
After adding the secret, test with:
1. Manual workflow dispatch to development environment
2. Verify webhook returns HTTP 2xx
3. Check deployment in Kubero UI at https://dev.theedgestory.org

## Breaking Changes
- `CORE_CHARTS_PAT` secret no longer needed (can be removed after successful deployment)
- Deployments now go through Kubero instead of updating Helm charts repository